### PR TITLE
Forum Posts feed: Add forum discussion start time check

### DIFF
--- a/classes/local.php
+++ b/classes/local.php
@@ -1816,6 +1816,7 @@ class local {
 	                     WHERE (cm1.groupmode <> :sepgps2a OR (gm1.userid IS NOT NULL $fgpsql))
 	                       AND fp1.userid <> :user2a
                            AND fp1.modified > $since
+                           AND fd1.timestart < " . time() . "
                       ORDER BY fp1.modified DESC
                                $limitsql
                         )


### PR DESCRIPTION
Discussions with a start time in the future are visible in the 'Forum Posts' feed on the 'My Courses' page. When a  student clicks on the discussion title, they are presented with an error message (which is expected as the discussion is not yet available).

This PR adds a WHERE clause checking that the discussion timestart is in the past.